### PR TITLE
Fix responsive for width less than 370

### DIFF
--- a/src/app/auth/SignIn.tsx
+++ b/src/app/auth/SignIn.tsx
@@ -12,7 +12,10 @@ export const SignIn = () => {
       <section className="flex flex-col items-center justify-center w-full">
         <h1 className="mb-6 text-2xl font-medium">Faça seu login</h1>
 
-        <form onSubmit={() => {}}>
+        <form
+          onSubmit={() => {}}
+          className="flex flex-col items-center justify-center w-full"
+        >
           <div className="flex flex-col mb-6 space-y-2">
             <Input
               Icon={() => <FaRegEnvelope className="text-gray-400" />}
@@ -28,7 +31,7 @@ export const SignIn = () => {
           </div>
 
           <button
-            className="flex items-center justify-center mb-6 transition-all duration-300 bg-yellow-500 rounded-lg hover:bg-yellow-600 w-80 h-14 dark:text-gray-900"
+            className="flex items-center justify-center max-w-xs mb-6 transition-all duration-300 bg-yellow-500 rounded-lg w-72 hover:bg-yellow-600 h-14 dark:text-gray-900"
             type="submit"
           >
             Entrar

--- a/src/app/ui/Input.tsx
+++ b/src/app/ui/Input.tsx
@@ -1,11 +1,17 @@
+type InputProps = {
+  type: string;
+  placeholder: string;
+  Icon: React.FC;
+};
+
 export const Input = ({
-  Icon = () => {},
+  Icon,
   type = 'text',
   placeholder = '',
-}: any) => {
+}: InputProps) => {
   return (
-    <div className="flex items-center p-4 transition-all duration-300 bg-white rounded-lg w-80 h-14 dark:bg-gray-900">
-      <Icon />
+    <div className="flex items-center max-w-xs p-4 transition-all duration-300 bg-white rounded-lg w-72 h-14 dark:bg-gray-900">
+      {Icon && <Icon />}
       <input
         type={type}
         placeholder={placeholder}


### PR DESCRIPTION
## Descrição
Este PR tem como objetivo, corrigir um bug do tamanho dos inputs e button na tela no signin quando é apresentado no mobile abaixo de 350px de width q ficavam muito colado nas laterais do aparalho. 

<br>

**PR relacionado:** <!--Adicionar link do PR que estiver relacionado a esta tarefa. **Ex: Um PR de backend**-->

<br>

## Screenshot de como era
Preste atenção nas laterais dos inputs e do button.
![Screenshot from 2021-09-19 11-34-57](https://user-images.githubusercontent.com/57181054/133924366-4cf78a60-f908-43fd-ad89-ec8f1b3f3ffd.png)

## Screenshot de como ficou

![Screenshot from 2021-09-19 11-35-25](https://user-images.githubusercontent.com/57181054/133924380-d4f13b10-2d5e-4090-bc63-f8ed074c4f94.png)


<br>

## Instruções de teste

<!--Adicionar instruções de o que é preciso para testar as alterações feitas.
**Ex: Atualizar libs do projeto (`docker-compose run --rm main npm install`)**-->

<br>

## Checklist de alterações

- [x] Revisei meu próprio código
- [x] Testei as alterações feitas (cuidei responsivo e outros possíveis erros)
- [x] Adicionei as labels do PR
- [x] Adicionei os reviewers do PR
- [x] Está pronto para o review!


